### PR TITLE
Fix issue with window.opener

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /bower_components
 
 # misc
+/.idea
 /.sass-cache
 /connect.lock
 /coverage/*

--- a/addon/services/client.js
+++ b/addon/services/client.js
@@ -52,7 +52,7 @@ export default Ember.Service.extend({
     }
     return (this.targets[name].opener && !this.targets[name].opener.closed);
   },
-  
+
   /*
    * @private
    * @return {Window}
@@ -85,7 +85,7 @@ export default Ember.Service.extend({
    */
   _isTargetParent(target) {
     let win = this._getWindow();
-    let isEmbedded = win.self !== win.top || win.opener;
+    let isEmbedded = win.self !== (win.top || win.opener);
     return isEmbedded || target === 'parent';
   },
 


### PR DESCRIPTION
I noticed this issue when was trying to open a part of my application in a new tab (using link with target="_blank"). Basically this code means that whenever `window.opener` is specified, it is returned by this method (`_isTargetParent`) instead of boolean value, and thus always considered `true` in boolean context. So even when I specify messenger's target, it doesn't matter for `_targetFor` method which always returns actual window when it's opened in a new tab.

My guess was that you meant to wrap this condition into parenthesis: `win.self !== (win.top || win.opener)`. Please correct me if I'm wrong.