### PR TITLE
Do not use global event variable

### DIFF
--- a/addon/services/server.js
+++ b/addon/services/server.js
@@ -32,8 +32,9 @@ export default Ember.Service.extend(Ember.Evented, {
    * Handle message that we got from Messenger Events
    *
    * @param  {Object} message
+   * @param  {Object} event
    */
-  _onMessage(message) {
+  _onMessage(message, event) {
     this.trigger(message.name, (response) => {
       this._respond(message.id, response, event, false);
     }, (response) => {

--- a/addon/services/window-messenger-events.js
+++ b/addon/services/window-messenger-events.js
@@ -53,7 +53,7 @@ export default Service.extend(Evented, {
     if (this._isOriginAllowed(event.origin)) {
       let message = this._parseMessage(event.data);
       if (message !== null) {
-        this.trigger(`from:${message.type}`, message);
+        this.trigger(`from:${message.type}`, message, event);
       }
     }
     return null;


### PR DESCRIPTION
Hi I found this issue while testing my site in firefox browser.
Ember window messenger is using "event" global variable which is not supported by firefox browser.
So I updated code to pass event param while triggering "**from:ember-window-messenger-client**" event so that listener in the **server service** can use.