### PR TITLE
Add ability to allow/disallow origins after initial config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ APP: {
 
 This list is also used for validation, to check if message comes from an allowed origin.
 
+You can also allow/disallow origins dynamically:
+
+```javascript
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  windowMessengerEvents: Ember.inject.service('window-messenger-events'),
+
+  init() {
+    this._super(...arguments);
+
+    this.get('windowMessengerEvents').allowOrigin('example', 'http://localhost:4200');
+    this.get('windowMessengerEvents').disallowOrigin('popup');
+   }
+});
+```
+
 ### Examples
 
 If you dare, fire up the dummy app in this addon and test it out. Below are the basic examples, see dummy app for more.

--- a/README.md
+++ b/README.md
@@ -38,11 +38,14 @@ You can also allow/disallow origins dynamically:
 import Ember from 'ember';
 
 export default Ember.Route.extend({
+  windowMessengerClient: Ember.inject.service('window-messenger-client'),
   windowMessengerEvents: Ember.inject.service('window-messenger-events'),
 
   init() {
     this._super(...arguments);
 
+    this.get('windowMessengerClient').allowOrigin('example', 'http://localhost:4200');
+    this.get('windowMessengerClient').disallowOrigin('popup');
     this.get('windowMessengerEvents').allowOrigin('example', 'http://localhost:4200');
     this.get('windowMessengerEvents').disallowOrigin('popup');
    }

--- a/addon/services/window-messenger-events.js
+++ b/addon/services/window-messenger-events.js
@@ -22,6 +22,27 @@ export default Service.extend(Evented, {
   },
 
   /**
+   * Allow a new origin to send messages
+   *
+   * @param {String} name - friendly name for the allowed message origin
+   * @param {String} origin - origin URL
+   */
+  allowOrigin(name, origin) {
+    this.get('targetOriginMap')[name] = origin;
+    this.notifyPropertyChange('targetOriginMap');
+  },
+
+  /**
+   * Disallow an origin from sending messages
+   *
+   * @param {String} name - friendly name for the disallowed message origin
+   */
+  disallowOrigin(name) {
+    delete this.get('targetOriginMap')[name];
+    this.notifyPropertyChange('targetOriginMap');
+  },
+
+  /**
    * @private
    * @return {Window}
    */

--- a/app/services/window-messenger-client.js
+++ b/app/services/window-messenger-client.js
@@ -5,6 +5,6 @@ export default Client.extend({
   targetOriginMap: null,
   init() {
     this._super(...arguments);
-    this.set('targetOriginMap', config.APP['ember-window-messenger'] || {});
+    this.set('targetOriginMap', Object.assign({}, config.APP['ember-window-messenger'] || {}));
   }
 });

--- a/app/services/window-messenger-events.js
+++ b/app/services/window-messenger-events.js
@@ -5,6 +5,6 @@ export default EventsService.extend({
   targetOriginMap: null,
   init() {
     this._super(...arguments);
-    this.set('targetOriginMap', config.APP['ember-window-messenger'] || {});
+    this.set('targetOriginMap', Object.assign({}, config.APP['ember-window-messenger'] || {}));
   }
 });

--- a/tests/unit/services/window-messenger-client-test.js
+++ b/tests/unit/services/window-messenger-client-test.js
@@ -112,4 +112,26 @@ module('Unit | Service | window messenger client', function(hooks) {
     })
     await settled();
   });
+
+  test('it should send fetch successfully after allowing origin', async function(assert) {
+    const client = this.owner.lookup('service:window-messenger-client'),
+      server = this.owner.lookup('service:window-messenger-server');
+
+    client.set('targetOriginMap', {});
+    client.allowOrigin('test', 'http://localhost:7357');
+    client.addTarget('test', window);
+
+    server.on('client-request', (resolve) => {
+      resolve('Hello');
+    });
+    await client.fetch('test:client-request').then((response) => assert.equal(response, 'Hello'));
+  });
+
+  test('it should have no allowed origins after removing default origins', async function(assert) {
+    const client = this.owner.lookup('service:window-messenger-client');
+    client.disallowOrigin('parent');
+    client.disallowOrigin('target-1');
+
+    assert.deepEqual(client.get('allowedOrigins'), []);
+  });
 });

--- a/tests/unit/services/window-messenger-events-test.js
+++ b/tests/unit/services/window-messenger-events-test.js
@@ -47,4 +47,33 @@ module('Unit | Service | window messenger events', function(hooks) {
 
     window.postMessage(message, 'http://localhost:9999');
   })
+
+  test('it should handle message after allowing origin', async function(assert) {
+    assert.expect(1);
+
+    const service = this.owner.lookup('service:window-messenger-events');
+    const message = JSON.stringify({
+      id: +new Date(),
+      type: 'test-dummy',
+      name: 'hello-world',
+      query: {}
+    });
+
+    service.set('targetOriginMap', {});
+    service.allowOrigin('test', 'http://localhost:7357');
+
+    service.on('from:test-dummy', () => {
+      assert.ok(true);
+    });
+
+    window.postMessage(message, '*');
+  });
+
+  test('it should have no allowed origins after removing default origins', async function(assert) {
+    const service = this.owner.lookup('service:window-messenger-events');
+    service.disallowOrigin('parent');
+    service.disallowOrigin('target-1');
+
+    assert.deepEqual(service.get('allowedOrigins'), []);
+  });
 });


### PR DESCRIPTION
The Object.assign call in app/services/window-messenger-events.js ensures that calls to allowOrigin/disallowOrigin do not overwrite config.APP['ember-window-messenger'] (it was previously passed by reference). This was caught in the unit tests as the service was being reinitialized in other tests but missing the origins removed in 'it should have no allowed origins after removing default origins'.