### PR TITLE
Use lightweight event registration in each of the services, no Ember.Evented

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
   },
   rules: {
     'ember/classic-decorator-hooks': 'off', // need to setup client/server messagebus differently
-    'ember/no-classic-classes': 'off', // need get rid of Evented mixin first
   },
   overrides: [
     // node files

--- a/addon/services/client.js
+++ b/addon/services/client.js
@@ -14,11 +14,12 @@ export default class WindowMessengerClientService extends Service {
   callbacks = {};
   targets = {};
 
+  targetOriginMap = {}; // This is set from environment config automatically
+
   init() {
     super.init();
     this.windowMessengerEvents.on(
       'from:ember-window-messenger-server',
-      this,
       this._onMessage
     );
   }
@@ -183,7 +184,7 @@ export default class WindowMessengerClientService extends Service {
    * @private
    * @param  {Object} message
    */
-  _onMessage(message) {
+  _onMessage = (message) => {
     let { response, id, error } = message;
     let inQueue = this.callbacks[id];
 
@@ -195,13 +196,12 @@ export default class WindowMessengerClientService extends Service {
       }
     }
     delete this.callbacks[id];
-  }
+  };
 
   willDestroy() {
     super.willDestroy();
     this.windowMessengerEvents.off(
       'from:ember-window-messenger-server',
-      this,
       this._onMessage
     );
   }

--- a/app/services/window-messenger-client.js
+++ b/app/services/window-messenger-client.js
@@ -1,10 +1,6 @@
 import config from '../config/environment';
 import Client from 'ember-window-messenger/services/client';
 
-export default Client.extend({
-  targetOriginMap: null,
-  init() {
-    this._super(...arguments);
-    this.set('targetOriginMap', config.APP['ember-window-messenger'] || {});
-  },
-});
+export default class WindowMessengerClientService extends Client {
+  targetOriginMap = config.APP['ember-window-messenger'] || {};
+}

--- a/app/services/window-messenger-events.js
+++ b/app/services/window-messenger-events.js
@@ -1,10 +1,6 @@
 import config from '../config/environment';
 import EventsService from 'ember-window-messenger/services/window-messenger-events';
 
-export default EventsService.extend({
-  targetOriginMap: null,
-  init() {
-    this._super(...arguments);
-    this.set('targetOriginMap', config.APP['ember-window-messenger'] || {});
-  },
-});
+export default class WindowMessengerEventsService extends EventsService {
+  targetOriginMap = config.APP['ember-window-messenger'] || {};
+}


### PR DESCRIPTION
Remove dependency on Ember.Evented. This allowed to convert service to native classes and now I need to figure out how to setup those services without using init() method from classic Ember idioms.