### PR TITLE
Lazily register event listeners for messages, no init() methods

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,9 +19,7 @@ module.exports = {
   env: {
     browser: true,
   },
-  rules: {
-    'ember/classic-decorator-hooks': 'off', // need to setup client/server messagebus differently
-  },
+  rules: {},
   overrides: [
     // node files
     {

--- a/addon/services/client.js
+++ b/addon/services/client.js
@@ -16,14 +16,6 @@ export default class WindowMessengerClientService extends Service {
 
   targetOriginMap = {}; // This is set from environment config automatically
 
-  init() {
-    super.init();
-    this.windowMessengerEvents.on(
-      'from:ember-window-messenger-server',
-      this._onMessage
-    );
-  }
-
   /**
    * Add new contentWindow target
    *
@@ -147,6 +139,8 @@ export default class WindowMessengerClientService extends Service {
     assert(`Target window is not registered for: ${targetName}`, target);
 
     return new EmberPromise((resolve, reject) => {
+      this._lazyRegisterMessagesListener();
+
       let uuid = guidFor(queryObject);
       let query = {
         id: uuid,
@@ -197,6 +191,13 @@ export default class WindowMessengerClientService extends Service {
     }
     delete this.callbacks[id];
   };
+
+  _lazyRegisterMessagesListener() {
+    this.windowMessengerEvents.on(
+      'from:ember-window-messenger-server',
+      this._onMessage
+    );
+  }
 
   willDestroy() {
     super.willDestroy();

--- a/addon/services/server.js
+++ b/addon/services/server.js
@@ -6,14 +6,6 @@ export default class WindowMessengerServerService extends Service {
 
   registeredResources = {};
 
-  init() {
-    super.init();
-    this.windowMessengerEvents.on(
-      'from:ember-window-messenger-client',
-      this._onMessage
-    );
-  }
-
   /**
    * Send response to back to client
    *
@@ -51,6 +43,13 @@ export default class WindowMessengerServerService extends Service {
     );
   };
 
+  _lazyRegisterMessagesListener() {
+    this.windowMessengerEvents.on(
+      'from:ember-window-messenger-client',
+      this._onMessage
+    );
+  }
+
   willDestroy() {
     super.willDestroy();
     this.windowMessengerEvents.off(
@@ -60,6 +59,7 @@ export default class WindowMessengerServerService extends Service {
   }
 
   on(resourceName, callback) {
+    this._lazyRegisterMessagesListener();
     this.registeredResources[resourceName] = callback;
   }
 

--- a/addon/services/window-messenger-events.js
+++ b/addon/services/window-messenger-events.js
@@ -21,6 +21,9 @@ export default class WindowMessengerEventService extends Service {
   }
 
   on(eventName, callback) {
+    if (eventName in this.registeredEvents) {
+      return;
+    }
     this.registeredEvents[eventName] = callback;
   }
 


### PR DESCRIPTION
With this PR all lint rules that were disabled are enabled again.