### PR TITLE
Add has() method to window-messenger-server

### DIFF
--- a/addon/services/server.ts
+++ b/addon/services/server.ts
@@ -10,7 +10,7 @@ export default class WindowMessengerServerService extends Service {
   @service('window-messenger-events')
   windowMessengerEvents!: WindowMessengerEventService;
 
-  registeredResources: {
+  private _registeredResources: {
     [key: string]: OnEventCallback<unknown, unknown, unknown>;
   } = {};
 
@@ -89,15 +89,19 @@ export default class WindowMessengerServerService extends Service {
     callback: OnEventCallback<Resolve, Reject, Query>
   ) {
     this._lazyRegisterMessagesListener();
-    this.registeredResources[resourceName] = callback;
+    this._registeredResources[resourceName] = callback;
+  }
+
+  has(resourceName: string): boolean {
+    return resourceName in this._registeredResources;
   }
 
   off(
     resourceName: string,
     callback: OnEventCallback<unknown, unknown, unknown>
   ) {
-    if (this.registeredResources[resourceName] === callback) {
-      delete this.registeredResources[resourceName];
+    if (this._registeredResources[resourceName] === callback) {
+      delete this._registeredResources[resourceName];
     }
   }
 
@@ -107,7 +111,7 @@ export default class WindowMessengerServerService extends Service {
     reject: RejectMethod<Reject>,
     query: Query & Q
   ) {
-    const cb = this.registeredResources[resourceName];
+    const cb = this._registeredResources[resourceName];
     if (cb) {
       cb(resolve, reject, query);
     }

--- a/tests/unit/services/window-messenger-server-test.ts
+++ b/tests/unit/services/window-messenger-server-test.ts
@@ -8,6 +8,17 @@ import WindowMessengerServerService, {
 module('Unit | Service | window messenger server', function (hooks) {
   setupTest(hooks);
 
+  test('has() resource method', async function (assert) {
+    const server: WindowMessengerServerService = this.owner.lookup(
+      'service:window-messenger-server'
+    );
+    assert.false(server.has('client-request'), 'has no resource');
+    server.on('client-request', (resolve /*, reject, query*/) => {
+      resolve();
+    });
+    assert.true(server.has('client-request'), 'has resource');
+  });
+
   test("it should receive client's request", async function (assert) {
     assert.expect(1);
     const server: WindowMessengerServerService = this.owner.lookup(


### PR DESCRIPTION
This PR adds has() method to server service which can be used to check if there is already registered resource.

Also marking internal data structure as private.