### PR TITLE
Add test waiter support for waiting async postMessages in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "postpack": "ember ts:clean"
   },
   "dependencies": {
+    "@ember/test-waiters": "^3.0.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-typescript": "^4.2.1"
   },

--- a/tests/unit/services/window-messenger-server-test.ts
+++ b/tests/unit/services/window-messenger-server-test.ts
@@ -4,6 +4,7 @@ import { settled } from '@ember/test-helpers';
 import WindowMessengerServerService, {
   OnEventCallback,
 } from 'ember-window-messenger/services/server';
+import WindowMessengerClientService from 'ember-window-messenger/services/client';
 
 module('Unit | Service | window messenger server', function (hooks) {
   setupTest(hooks);
@@ -24,7 +25,9 @@ module('Unit | Service | window messenger server', function (hooks) {
     const server: WindowMessengerServerService = this.owner.lookup(
       'service:window-messenger-server'
     );
-    const client = this.owner.lookup('service:window-messenger-client');
+    const client: WindowMessengerClientService = this.owner.lookup(
+      'service:window-messenger-client'
+    );
 
     server.on('client-request', (resolve /*, reject, query*/) => {
       assert.ok(true);
@@ -39,7 +42,9 @@ module('Unit | Service | window messenger server', function (hooks) {
     const server: WindowMessengerServerService = this.owner.lookup(
       'service:window-messenger-server'
     );
-    const client = this.owner.lookup('service:window-messenger-client');
+    const client: WindowMessengerClientService = this.owner.lookup(
+      'service:window-messenger-client'
+    );
 
     server.on('client-request', (/*resolve, reject, query*/) => {
       assert.ok(true);
@@ -52,7 +57,9 @@ module('Unit | Service | window messenger server', function (hooks) {
     const server: WindowMessengerServerService = this.owner.lookup(
       'service:window-messenger-server'
     );
-    const client = this.owner.lookup('service:window-messenger-client');
+    const client: WindowMessengerClientService = this.owner.lookup(
+      'service:window-messenger-client'
+    );
 
     server.on<null, null, { id: number }>(
       'client-request',
@@ -72,13 +79,16 @@ module('Unit | Service | window messenger server', function (hooks) {
     const server: WindowMessengerServerService = this.owner.lookup(
       'service:window-messenger-server'
     );
-    const client = this.owner.lookup('service:window-messenger-client');
+    const client: WindowMessengerClientService = this.owner.lookup(
+      'service:window-messenger-client'
+    );
 
     server.on('client-request', () => {
       assert.ok(true);
     });
     client.fetch('client-request');
     server.destroy();
+    client.destroy(); // TODO remove once timeout is implemented
     await settled();
   });
 
@@ -87,7 +97,9 @@ module('Unit | Service | window messenger server', function (hooks) {
     const server: WindowMessengerServerService = this.owner.lookup(
       'service:window-messenger-server'
     );
-    const client = this.owner.lookup('service:window-messenger-client');
+    const client: WindowMessengerClientService = this.owner.lookup(
+      'service:window-messenger-client'
+    );
 
     const handler: OnEventCallback<null, null, null> = () => {
       assert.ok(true);
@@ -95,6 +107,7 @@ module('Unit | Service | window messenger server', function (hooks) {
     server.on('client-request', handler);
     server.off('client-request', handler);
     client.fetch('client-request');
+    client.destroy(); // TODO remove once timeout is implemented
     await settled();
   });
 });


### PR DESCRIPTION
This PR enables better testing capabilities for apps by waiting for pending async postMessages to be finished.